### PR TITLE
Adds ability to pass a query parameter specifying a remote target for the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ scripts:
     script: sleep 5
     timeout: 1
 
-  - name: target
-    script: example.sh ${TARGET}
+  - name: ping-target
+    script: ping -c 1 ${TARGET}
     timeout: 4
 ```
 
@@ -78,7 +78,7 @@ parameter is made available to the script's environment with the name `TARGET`.
 This, for example, allows you to leverage Prometheus targets, if you happen to
 need the script to operate on an arbitrary number of remote hosts/services.
 
-`$ curl http://localhost:9172/probe?name=example&target=service.example.com`
+`$ curl http://localhost:9172/probe?name=ping-target&target=service.example.com`
 
 ## Design
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ scripts:
   - name: timeout
     script: sleep 5
     timeout: 1
+
+  - name: target
+    script: example.sh
+    timeout: 4
+    target: service.example.com
 ```
 
 ## Running
@@ -56,7 +61,7 @@ script_duration_seconds{script="failure"} 2.008337
 script_success{script="failure"} 0
 ```
 
-A regular expression may be specified withthe `pattern` paremeter:
+A regular expression may be specified with the `pattern` paremeter:
 
 `$ curl http://localhost:9172/probe?pattern=.*`
 
@@ -68,6 +73,14 @@ script_success{script="failure"} 0
 script_duration_seconds{script="success"} 5.013670
 script_success{script="success"} 1
 ```
+
+A `target` can be specified for each script in the configuration file, or, more
+usefully, passed as a parameter which is made available to the script(s) that
+gets run as an environment variable named `$TARGET`. This allows you to leverage
+Prometheus targets, if you happen to need the script to operate on an arbitrary
+number of remote hosts/services.
+
+`$ curl http://localhost:9172/probe?name=example.sh&target=service.example.com`
 
 ## Design
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ scripts:
     timeout: 1
 
   - name: target
-    script: example.sh
+    script: example.sh ${TARGET}
     timeout: 4
-    target: service.example.com
 ```
 
 ## Running
@@ -74,13 +73,12 @@ script_duration_seconds{script="success"} 5.013670
 script_success{script="success"} 1
 ```
 
-A `target` can be specified for each script in the configuration file, or, more
-usefully, passed as a parameter which is made available to the script(s) that
-gets run as an environment variable named `$TARGET`. This allows you to leverage
-Prometheus targets, if you happen to need the script to operate on an arbitrary
-number of remote hosts/services.
+If a /probe query parameter named `target` is present, then the value of this
+parameter is made available to the script's environment with the name `TARGET`.
+This, for example, allows you to leverage Prometheus targets, if you happen to
+need the script to operate on an arbitrary number of remote hosts/services.
 
-`$ curl http://localhost:9172/probe?name=example.sh&target=service.example.com`
+`$ curl http://localhost:9172/probe?name=example&target=service.example.com`
 
 ## Design
 

--- a/script_exporter.go
+++ b/script_exporter.go
@@ -33,8 +33,8 @@ type Config struct {
 type Script struct {
 	Name    string `yaml:"name"`
 	Content string `yaml:"script"`
-	Target  string `yaml:"target"`
 	Timeout int64  `yaml:"timeout"`
+	Target  string
 }
 
 type Measurement struct {
@@ -110,6 +110,11 @@ func scriptFilter(scripts []*Script, name, pattern, target string) (filteredScri
 	}
 
 	var patternRegexp *regexp.Regexp
+	var targetRegexp *regexp.Regexp
+
+	// A *very* basic regex pattern to be sure that the target looks minimally
+	// like a domain name and contains no special shell characters.
+	var targetPattern string = "^[a-zA-Z0-9-.]{2,253}$"
 
 	if pattern != "" {
 		patternRegexp, err = regexp.Compile(pattern)
@@ -117,6 +122,12 @@ func scriptFilter(scripts []*Script, name, pattern, target string) (filteredScri
 		if err != nil {
 			return
 		}
+	}
+
+	targetRegexp, err = regexp.Compile(targetPattern)
+	if target != "" && ! targetRegexp.MatchString(target) {
+		log.Infof("The query parameter 'target' is not valid: %s", target)
+		return
 	}
 
 	for _, script := range scripts {

--- a/script_exporter.go
+++ b/script_exporter.go
@@ -24,6 +24,10 @@ var (
 	listenAddress = flag.String("web.listen-address", ":9172", "The address to listen on for HTTP requests.")
 	metricsPath   = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 	shell         = flag.String("config.shell", "/bin/sh", "Shell to execute script")
+	// A regex pattern that only matches valid ASCII domain name characters to
+	// prevent inadvertent or malicious injection of special shell characters
+	// into the scripts environment.
+	targetRegexp = regexp.MustCompile("^[a-zA-Z0-9-.]{4,253}$")
 )
 
 type Config struct {
@@ -110,11 +114,6 @@ func scriptFilter(scripts []*Script, name, pattern, target string) (filteredScri
 	}
 
 	var patternRegexp *regexp.Regexp
-
-	// A regex pattern that only matches valid ASCII domain name characters to
-	// prevent inadvertent or malicious injection of special shell characters
-	// into the scripts environment.
-	var targetRegexp = regexp.MustCompile("^[a-zA-Z0-9-.]{4,253}$")
 
 	if pattern != "" {
 		patternRegexp, err = regexp.Compile(pattern)

--- a/script_exporter.go
+++ b/script_exporter.go
@@ -110,11 +110,11 @@ func scriptFilter(scripts []*Script, name, pattern, target string) (filteredScri
 	}
 
 	var patternRegexp *regexp.Regexp
-	var targetRegexp *regexp.Regexp
 
-	// A *very* basic regex pattern to be sure that the target looks minimally
-	// like a domain name and contains no special shell characters.
-	var targetPattern string = "^[a-zA-Z0-9-.]{2,253}$"
+	// A regex pattern that only matches valid ASCII domain name characters to
+	// prevent inadvertent or malicious injection of special shell characters
+	// into the scripts environment.
+	var targetRegexp = regexp.MustCompile("^[a-zA-Z0-9-.]{4,253}$")
 
 	if pattern != "" {
 		patternRegexp, err = regexp.Compile(pattern)
@@ -124,9 +124,7 @@ func scriptFilter(scripts []*Script, name, pattern, target string) (filteredScri
 		}
 	}
 
-	targetRegexp, err = regexp.Compile(targetPattern)
-	if target != "" && ! targetRegexp.MatchString(target) {
-		log.Infof("The query parameter 'target' is not valid: %s", target)
+	if target != "" && !targetRegexp.MatchString(target) {
 		return
 	}
 

--- a/script_exporter_test.go
+++ b/script_exporter_test.go
@@ -6,9 +6,9 @@ import (
 
 var config = &Config{
 	Scripts: []*Script{
-		{"success", "exit 0", 1},
-		{"failure", "exit 1", 1},
-		{"timeout", "sleep 5", 2},
+		{"success", "exit 0", "", 1},
+		{"failure", "exit 1", "", 1},
+		{"timeout", "sleep 5", "", 2},
 	},
 }
 
@@ -39,7 +39,7 @@ func TestRunScripts(t *testing.T) {
 
 func TestScriptFilter(t *testing.T) {
 	t.Run("RequiredParameters", func(t *testing.T) {
-		_, err := scriptFilter(config.Scripts, "", "")
+		_, err := scriptFilter(config.Scripts, "", "", "")
 
 		if err.Error() != "`name` or `pattern` required" {
 			t.Errorf("Expected failure when supplying no parameters")
@@ -47,7 +47,7 @@ func TestScriptFilter(t *testing.T) {
 	})
 
 	t.Run("NameMatch", func(t *testing.T) {
-		scripts, err := scriptFilter(config.Scripts, "success", "")
+		scripts, err := scriptFilter(config.Scripts, "success", "", "")
 
 		if err != nil {
 			t.Errorf("Unexpected: %s", err.Error())
@@ -59,7 +59,7 @@ func TestScriptFilter(t *testing.T) {
 	})
 
 	t.Run("PatternMatch", func(t *testing.T) {
-		scripts, err := scriptFilter(config.Scripts, "", "fail.*")
+		scripts, err := scriptFilter(config.Scripts, "", "fail.*", "")
 
 		if err != nil {
 			t.Errorf("Unexpected: %s", err.Error())
@@ -70,8 +70,26 @@ func TestScriptFilter(t *testing.T) {
 		}
 	})
 
+	t.Run("TargetSet", func(t *testing.T) {
+		scripts, err := scriptFilter(config.Scripts, "", ".*", "example.com")
+
+		if err != nil {
+			t.Errorf("Unexpected: %s", err.Error())
+		}
+
+		if len(scripts) != 3 {
+			t.Fatalf("Expected 3 scripts, received %d", len(scripts))
+		}
+
+		for i, script := range config.Scripts {
+			if script.Target != "example.com" {
+				t.Fatalf("Target not set on script %s", scripts[i].Name)
+			}
+		}
+	})
+
 	t.Run("AllMatch", func(t *testing.T) {
-		scripts, err := scriptFilter(config.Scripts, "success", ".*")
+		scripts, err := scriptFilter(config.Scripts, "success", ".*", "")
 
 		if err != nil {
 			t.Errorf("Unexpected: %s", err.Error())

--- a/script_exporter_test.go
+++ b/script_exporter_test.go
@@ -6,9 +6,9 @@ import (
 
 var config = &Config{
 	Scripts: []*Script{
-		{"success", "exit 0", "", 1},
-		{"failure", "exit 1", "", 1},
-		{"timeout", "sleep 5", "", 2},
+		{"success", "exit 0", 1, ""},
+		{"failure", "exit 1", 1, ""},
+		{"timeout", "sleep 5", 2, ""},
 	},
 }
 
@@ -85,6 +85,18 @@ func TestScriptFilter(t *testing.T) {
 			if script.Target != "example.com" {
 				t.Fatalf("Target not set on script %s", scripts[i].Name)
 			}
+		}
+	})
+
+	t.Run("TargetInvalid", func(t *testing.T) {
+		scripts, err := scriptFilter(config.Scripts, "success", "", "example.com;rm -rf /")
+
+		if err != nil {
+			t.Errorf("Unexpected: %s", err.Error())
+		}
+
+		if len(scripts) != 0 {
+			t.Fatalf("Expected 0 scripts, received %d", len(scripts))
 		}
 	})
 


### PR DESCRIPTION
Hello! Thank you for this exporter.

This exporter was close to meeting our needs, but lacked one important feature: the ability to pass a remote target as a query parameter. This is a somewhat standard capability of a number of other Prometheus exporters (e.g., [snmp_exporter](https://github.com/prometheus/snmp_exporter#usage)). Our use case is that we need to run a particular script against hundreds of remote targets. We configure Prometheus to probe this exporter, passing the remote target as the value of the target query parameter.

This PR adds the ability to pass a &target=<sometarget> query parameter to the probe endpoint. The value of this query parameter is then injected into the environment of the called script with the name TARGET.

Maybe you would find this a useful addition to your exporter?

Thanks,

Nathan