### PR TITLE
add support to use script file instead of just script in single line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER  James Kassemi (Ad Hoc, LLC) <james.kassemi@adhocteam.us>
 
 COPY script-exporter /bin/script-exporter
 COPY script-exporter.yml /etc/script-exporter/config.yml
+COPY runThis.sh /etc/script-exporter/runThis.sh
 
 EXPOSE      9172
 ENTRYPOINT  [ "/bin/script-exporter" ]

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ You can run via docker with:
 ```
 docker run -d -p 9172:9172 --name script-exporter \
   -v `pwd`/config.yml:/etc/script-exporter/config.yml:ro \
-  -config.file=/etc/script-exporter/config.yml
-  -web.listen-address=":9172" \
-  -web.telemetry-path="/metrics" \
-  -config.shell="/bin/sh" \
+  -e config.file=/etc/script-exporter/config.yml \
+  -e web.listen-address=":9172" \
+  -e web.telemetry-path="/metrics" \
+  -e config.shell="/bin/sh" \
   adhocteam/script-exporter:master
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ scripts:
   - name: timeout
     script: sleep 5
     timeout: 1
+    
+  - name: scriptFile
+      file: /etc/script-exporter/runThis.sh
 ```
 
 ## Running

--- a/runThis.sh
+++ b/runThis.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "This script is run while probing for the script"
+exit 0 # This will fail the script

--- a/script-exporter.yml
+++ b/script-exporter.yml
@@ -8,3 +8,6 @@ scripts:
   - name: 'timeout'
     script: sleep 5
     timeout: 1
+
+  - name: 'script'
+      file: /etc/script-exporter/runThis.sh

--- a/script_exporter.go
+++ b/script_exporter.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/version"
 	"bytes"
@@ -200,7 +201,7 @@ func main() {
 		}
 	}
 
-	http.Handle("/metrics", prometheus.Handler())
+	http.Handle("/metrics", promhttp.Handler())
 
 	http.HandleFunc("/probe", func(w http.ResponseWriter, r *http.Request) {
 		scriptRunHandler(w, r, &config)

--- a/script_exporter.go
+++ b/script_exporter.go
@@ -75,7 +75,7 @@ func runScript(script *Script) error {
 
 	err = bashCmd.Wait()
 
-	log.Debugf("output of script: %s", cmdOutput.Bytes())
+	log.Infof("output of script: %s", cmdOutput.Bytes())
 
 	if err != nil {
 		return err
@@ -98,7 +98,7 @@ func runScripts(scripts []*Script) []*Measurement {
 			duration := time.Since(start).Seconds()
 
 			if err == nil {
-				log.Debugf("OK: %s (after %fs).", script.Name, duration)
+				log.Infof("OK: %s (after %fs).", script.Name, duration)
 				success = 1
 			} else {
 				log.Infof("ERROR: %s: %s (failed after %fs).", script.Name, err, duration)

--- a/script_exporter_test.go
+++ b/script_exporter_test.go
@@ -6,9 +6,10 @@ import (
 
 var config = &Config{
 	Scripts: []*Script{
-		{"success", "exit 0", 1},
-		{"failure", "exit 1", 1},
-		{"timeout", "sleep 5", 2},
+		{"success", "exit 0", 1, ""},
+		{"failure", "exit 1", 1, ""},
+		{"timeout", "sleep 5", 2, ""},
+		{"script", "", 1, "./runThis.sh"},
 	},
 }
 
@@ -22,6 +23,7 @@ func TestRunScripts(t *testing.T) {
 		"success": {1, 0},
 		"failure": {0, 0},
 		"timeout": {0, 2},
+		"script": {1, 0},
 	}
 
 	for _, measurement := range measurements {
@@ -77,8 +79,8 @@ func TestScriptFilter(t *testing.T) {
 			t.Errorf("Unexpected: %s", err.Error())
 		}
 
-		if len(scripts) != 3 {
-			t.Fatalf("Expected 3 scripts, received %d", len(scripts))
+		if len(scripts) != 4 {
+			t.Fatalf("Expected 4 scripts, received %d", len(scripts))
 		}
 
 		for i, script := range config.Scripts {


### PR DESCRIPTION
I used script exporter for sometime. Its flexible to be able to use the shell scripts as probe, instead of just single line scripts.