### PR TITLE
Adding promhttp

### DIFF
--- a/script_exporter.go
+++ b/script_exporter.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/version"
 )
@@ -182,7 +183,7 @@ func main() {
 		}
 	}
 
-	http.Handle("/metrics", prometheus.Handler())
+	http.Handle("/metrics", promhttp.Handler())
 
 	http.HandleFunc("/probe", func(w http.ResponseWriter, r *http.Request) {
 		scriptRunHandler(w, r, &config)


### PR DESCRIPTION
When creating our container it is failing when executing `go install -v ./...`
```
# script-exporter
./script_exporter.go:185:26: undefined: prometheus.Handler
The command '/bin/sh -c go install -v ./...' returned a non-zero code: 2
```
Following instructions in https://prometheus.io/docs/guides/go-application/ we have included promhttp 

It looks that is working now
