### PR TITLE
Added bash to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN promu build
 FROM alpine:3.8
 LABEL upstream="https://github.com/adhocteam/script_exporter"
 LABEL maintainer="james.kassemi@adhocteam.us"
+RUN apk add --no-cache bash
 COPY --from=build-env /go/script_exporter/script_exporter /bin/script-exporter
 COPY script-exporter.yml /etc/script-exporter/config.yml
 


### PR DESCRIPTION
This PR fixes issue #19. 
Tested with:
> $ docker run -d -p 9172:9172 --name script-exporter \                                                                                                                                              
  -v `pwd`/script-exporter.yml:/etc/script-exporter/config.yml:ro \
  test:latest \
  -config.file=/etc/script-exporter/config.yml \
  -web.listen-address=":9172" \
  -web.telemetry-path="/metrics" \
  -config.shell="/bin/bash"

> $ curl http://localhost:9172/probe\?name\=failure                                                                                                                                                  
script_duration_seconds{script="failure"} 2.007900
script_success{script="failure"} 0