### PR TITLE
Add support for exporting exitcode of script as metric

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -2,7 +2,7 @@ go:
     version: 1.14.1
     cgo: true
 repository:
-    path: github.com/adhocteam/script_exporter
+    path: github.com/useful-devops-tools/script_exporter
 build:
     flags: -a -tags 'netgo static_build'
     ldflags: |

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/adhocteam/script_exporter
+module github.com/useful-devops-tools/script_exporter
 
 go 1.14
 

--- a/script_exporter.go
+++ b/script_exporter.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"syscall"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -40,32 +41,35 @@ type Script struct {
 type Measurement struct {
 	Script   *Script
 	Success  int
+	ExitCode int
 	Duration float64
 }
 
-func runScript(script *Script) error {
+func runScript(script *Script) (err error, rc int) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(script.Timeout)*time.Second)
 	defer cancel()
 
-	bashCmd := exec.CommandContext(ctx, *shell)
+	cmd := exec.CommandContext(ctx, *shell)
 
-	bashIn, err := bashCmd.StdinPipe()
+	stdin, err := cmd.StdinPipe()
 
 	if err != nil {
-		return err
+		return err, 1
 	}
 
-	if err = bashCmd.Start(); err != nil {
-		return err
+	if _, err = stdin.Write([]byte(script.Content)); err != nil {
+		return err, 1
+	}
+	stdin.Close()
+
+	if err = cmd.Run(); err != nil {
+		exitError := err.(*exec.ExitError)
+		rc = exitError.Sys().(syscall.WaitStatus).ExitStatus()
+	} else {
+		rc = cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
 	}
 
-	if _, err = bashIn.Write([]byte(script.Content)); err != nil {
-		return err
-	}
-
-	bashIn.Close()
-
-	return bashCmd.Wait()
+	return err, rc
 }
 
 func runScripts(scripts []*Script) []*Measurement {
@@ -77,7 +81,7 @@ func runScripts(scripts []*Script) []*Measurement {
 		go func(script *Script) {
 			start := time.Now()
 			success := 0
-			err := runScript(script)
+			err, rc := runScript(script)
 			duration := time.Since(start).Seconds()
 
 			if err == nil {
@@ -91,6 +95,7 @@ func runScripts(scripts []*Script) []*Measurement {
 				Script:   script,
 				Duration: duration,
 				Success:  success,
+				ExitCode: rc,
 			}
 		}(script)
 	}
@@ -144,6 +149,7 @@ func scriptRunHandler(w http.ResponseWriter, r *http.Request, config *Config) {
 	for _, measurement := range measurements {
 		fmt.Fprintf(w, "script_duration_seconds{script=\"%s\"} %f\n", measurement.Script.Name, measurement.Duration)
 		fmt.Fprintf(w, "script_success{script=\"%s\"} %d\n", measurement.Script.Name, measurement.Success)
+		fmt.Fprintf(w, "script_exit_code{script=\"%s\"} %d\n", measurement.Script.Name, measurement.ExitCode)
 	}
 }
 

--- a/script_exporter_test.go
+++ b/script_exporter_test.go
@@ -18,10 +18,11 @@ func TestRunScripts(t *testing.T) {
 	expectedResults := map[string]struct {
 		success     int
 		minDuration float64
+		exitCode	int
 	}{
-		"success": {1, 0},
-		"failure": {0, 0},
-		"timeout": {0, 2},
+		"success": {1, 0, 0},
+		"failure": {0, 0, 1},
+		"timeout": {0, 2, -1},
 	}
 
 	for _, measurement := range measurements {
@@ -33,6 +34,10 @@ func TestRunScripts(t *testing.T) {
 
 		if measurement.Duration < expectedResult.minDuration {
 			t.Errorf("Expected duration %f < %f: %s", measurement.Duration, expectedResult.minDuration, measurement.Script.Name)
+		}
+
+		if measurement.ExitCode != expectedResult.exitCode {
+			t.Errorf("Expected exit code %d != %d: %s", measurement.ExitCode, expectedResult.exitCode, measurement.Script.Name)
 		}
 	}
 }


### PR DESCRIPTION
Unit tests passed successfully

git clone https://github.com/Rory898/script_exporter.git
Cloning into 'script_exporter'...
cd script_exporter
go test
go: downloading github.com/prometheus/client_golang v1.5.1
go: downloading github.com/prometheus/common v0.9.1
go: downloading gopkg.in/yaml.v2 v2.2.8
go: downloading gopkg.in/alecthomas/kingpin.v2 v2.2.6
go: downloading github.com/sirupsen/logrus v1.4.2
go: downloading golang.org/x/sys v0.0.0-20200331124033-c3d80250170d
go: downloading github.com/prometheus/client_model v0.2.0
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.1
go: downloading github.com/golang/protobuf v1.3.5
go: downloading github.com/cespare/xxhash/v2 v2.1.1
go: downloading github.com/prometheus/procfs v0.0.11
go: downloading github.com/beorn7/perks v1.0.1
go: downloading github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
go: downloading github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d
time="2020-07-20T11:18:08Z" level=info msg="ERROR: failure: exit status 1 (failed after 0.001056s)." source="script_exporter.go:91"
time="2020-07-20T11:18:10Z" level=info msg="ERROR: timeout: signal: killed (failed after 2.000578s)." source="script_exporter.go:91"
PASS
